### PR TITLE
Fix news timeline alignment and add months

### DIFF
--- a/index.html
+++ b/index.html
@@ -695,13 +695,15 @@
             position: relative;
             padding-left: 1rem;
             font-size: 0.95rem;
+            display: flex;
+            align-items: center;
         }
 
         .news-item::before {
             content: "";
             position: absolute;
             left: 0;
-            top: 0.5em;
+            top: 50%;
             width: 8px;
             height: 8px;
             background: #000;
@@ -1536,10 +1538,10 @@ Yushi&rsquo;s experience includes a range of data science projects, developing m
    <aside class="news-sidebar">
     <h3>Recent News</h3>
     <ul class="news-list">
-     <li class="news-item" tabindex="0"><span class="news-date">2025</span>Measuring what matters: Construct validity in large language model benchmarks.</li>
-     <li class="news-item" tabindex="0"><span class="news-date">2025</span>LINGOLY-TOO: Disentangling memorisation from reasoning with linguistic templatisation and orthographic obfuscation.</li>
-     <li class="news-item" tabindex="0"><span class="news-date">2025</span>Clinical knowledge in LLMs does not translate to human interactions.</li>
-     <li class="news-item" tabindex="0"><span class="news-date">2025</span>Evaluating the role of 'Constitutions' for learning from AI feedback.</li>
+     <li class="news-item" tabindex="0"><span class="news-date">May 2025</span>Measuring what matters: Construct validity in large language model benchmarks.</li>
+     <li class="news-item" tabindex="0"><span class="news-date">Jan 2025</span>LINGOLY-TOO: Disentangling memorisation from reasoning with linguistic templatisation and orthographic obfuscation.</li>
+     <li class="news-item" tabindex="0"><span class="news-date">Dec 2024</span>Clinical knowledge in LLMs does not translate to human interactions.</li>
+     <li class="news-item" tabindex="0"><span class="news-date">Dec 2024</span>Evaluating the role of 'Constitutions' for learning from AI feedback.</li>
      <li class="news-item" tabindex="0"><span class="news-date">Dec 2024</span>OxRML at NeurIPS 2024.</li>
    </ul>
   </aside>


### PR DESCRIPTION
## Summary
- align timeline dots with the centre of each date badge
- show month abbreviations on recent news items and order by date

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6849bf05249c832bae2881cc0d8123ac