### PR TITLE
Update news sidebar layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -805,46 +805,6 @@
    </div>
   </nav>
   <div class="layout">
-   <aside class="news-sidebar">
-    <h3>Recent News</h3>
-    <ul class="news-list">
-     <li class="news-item" tabindex="0">
-      <div class="news-header">
-       <span class="news-date">May 2025</span>
-       <span class="news-title">New paper!</span>
-      </div>
-      <span class="news-text">Measuring what matters: Construct validity in large language model benchmarks.</span>
-     </li>
-     <li class="news-item" tabindex="0">
-      <div class="news-header">
-       <span class="news-date">Jan 2025</span>
-       <span class="news-title">New paper!</span>
-      </div>
-      <span class="news-text">LINGOLY-TOO: Disentangling memorisation from reasoning with linguistic templatisation and orthographic obfuscation.</span>
-     </li>
-     <li class="news-item" tabindex="0">
-      <div class="news-header">
-       <span class="news-date">Dec 2024</span>
-       <span class="news-title">New paper!</span>
-      </div>
-      <span class="news-text">Clinical knowledge in LLMs does not translate to human interactions.</span>
-     </li>
-     <li class="news-item" tabindex="0">
-      <div class="news-header">
-       <span class="news-date">Dec 2024</span>
-       <span class="news-title">New paper!</span>
-      </div>
-      <span class="news-text">Evaluating the role of 'Constitutions' for learning from AI feedback.</span>
-     </li>
-     <li class="news-item" tabindex="0">
-      <div class="news-header">
-       <span class="news-date">Dec 2024</span>
-       <span class="news-title">OxRML @ NeurIPS 2024</span>
-      </div>
-      <span class="news-text">We presented five papers at NeurIPS 2024 and its constituent workshops.</span>
-     </li>
-    </ul>
-   </aside>
    <main class="container main-content">
    <section class="section" id="research">
     <div class="section-header">
@@ -1592,8 +1552,48 @@ Yushi&rsquo;s experience includes a range of data science projects, developing m
      </div>
     </div>
     </section>
-   </main>
-  </div>
+  </main>
+  <aside class="news-sidebar">
+   <h3>Recent news</h3>
+   <ul class="news-list">
+    <li class="news-item" tabindex="0">
+     <div class="news-header">
+      <span class="news-date">May 2025</span>
+      <span class="news-title">New paper!</span>
+     </div>
+     <span class="news-text">Measuring what matters: Construct validity in large language model benchmarks.</span>
+    </li>
+    <li class="news-item" tabindex="0">
+     <div class="news-header">
+      <span class="news-date">Jan 2025</span>
+      <span class="news-title">New paper!</span>
+     </div>
+     <span class="news-text">LINGOLY-TOO: Disentangling memorisation from reasoning with linguistic templatisation and orthographic obfuscation.</span>
+    </li>
+    <li class="news-item" tabindex="0">
+     <div class="news-header">
+      <span class="news-date">Dec 2024</span>
+      <span class="news-title">OxRML @ NeurIPS 2024</span>
+     </div>
+     <span class="news-text">We presented five papers at NeurIPS 2024 and its constituent workshops.</span>
+    </li>
+    <li class="news-item" tabindex="0">
+     <div class="news-header">
+      <span class="news-date">Dec 2024</span>
+      <span class="news-title">New paper!</span>
+     </div>
+     <span class="news-text">Clinical knowledge in LLMs does not translate to human interactions.</span>
+    </li>
+    <li class="news-item" tabindex="0">
+     <div class="news-header">
+      <span class="news-date">Dec 2024</span>
+      <span class="news-title">New paper!</span>
+     </div>
+     <span class="news-text">Evaluating the role of 'Constitutions' for learning from AI feedback.</span>
+    </li>
+   </ul>
+  </aside>
+ </div>
   <footer class="footer">
    <p>
     &copy; 2024 Reasoning with Machines AI Lab, Oxford University. All rights reserved.


### PR DESCRIPTION
## Summary
- keep the news sidebar on the right-hand side
- rename the heading to "Recent news"
- reorder December 2024 items so that OxRML @ NeurIPS appears first

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684ac9116610832b96f261f2617d5c2a